### PR TITLE
Add support for Public Clients and add PKCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ configured with the Apache HTTP server and the
 [Keystone Open ID Connect plugin](https://github.com/IFCA/keystone-oidc-auth-plugin).
 
 This plugin requires that you configure an OpenID Connect client in your OpenID
-Connect Provider and pass the client credentials to the plugin. The OpenStack
-CLI will handle the authentication with the OpenID Connect Provider, obtaining
-and access token, that will be exchanged with the Keystone server in order to
-obtain a Keystone token.
+Connect Provider and pass the client credentials to the plugin. For public clients,
+omit the client_secret and
+[Proof Key for Code Exchange (PKCE)](https://tools.ietf.org/html/rfc7636) will be added
+to the request.
 
+The OpenStack CLI will handle the authentication with the OpenID Connect
+Provider, obtaining and access token, that will be exchanged with the Keystone
+server in order to obtain a Keystone token.
 
 ## Installation
 
@@ -91,7 +94,8 @@ First of all, you need to create an OpenID Connect client in your OpenID Connect
 Then, you have to specify the `v3oidccode` in the `--os-auth-type` option and provide a
 valid autorization endpoint with `--os-authorization-endpoint` or a valid discovery
 endpoint with `--os-discovery-endpoint`. The `<identity-provider>` and
-`<protocol>` must be provided by the OpenStack cloud provider.
+`<protocol>` must be provided by the OpenStack cloud provider. For public clients that
+lack a client_secret, the `--os-client-secret` field can be omitted.
 
 - Unscoped token:
 
@@ -101,7 +105,7 @@ endpoint with `--os-discovery-endpoint`. The `<identity-provider>` and
             --os-protocol <protocol> \
             --os-identity-api-version 3 \
             --os-client-id <OpenID Connect client ID> \
-            --os-client-secret <OpenID Connect client secret> \
+            [--os-client-secret <OpenID Connect client secret> \]
             --os-discovery-endpoint https://idp.example.org/.well-known/openid-configuration \
             --os-openid-scope "openid profile email" \
             token issue
@@ -116,7 +120,7 @@ endpoint with `--os-discovery-endpoint`. The `<identity-provider>` and
             --os-project-domain-id <project-domain> \
             --os-identity-api-version 3 \
             --os-client-id <OpenID Connect client ID> \
-            --os-client-secret <OpenID Connect client secret> \
+            [--os-client-secret <OpenID Connect client secret> \]
             --os-discovery-endpoint https://idp.example.org/.well-known/openid-configuration \
             --os-openid-scope "openid profile email" \
             token issue

--- a/keystoneauth_oidc/plugin.py
+++ b/keystoneauth_oidc/plugin.py
@@ -127,8 +127,8 @@ class OidcAuthorizationCode(oidc._OidcBase):
     grant_type = 'authorization_code'
 
     @positional(4)
-    def __init__(self, auth_url, identity_provider, protocol,
-                 client_id, client_secret,
+    def __init__(self, auth_url, identity_provider, protocol, client_id,
+                 client_secret=None,
                  access_token_endpoint=None,
                  authorization_endpoint=None,
                  discovery_endpoint=None,
@@ -162,7 +162,8 @@ class OidcAuthorizationCode(oidc._OidcBase):
         self.redirect_host = redirect_host
         self.redirect_port = int(redirect_port)
         self.redirect_uri = "http://%s:%s" % (self.redirect_host, self.redirect_port)
-        self.code_verifier, self.code_challenge = None
+        self.code_verifier = None
+        self.code_challenge = None
         if client_secret in ['', None]:
             self.code_verifier, self.code_challenge = pkce.generate_pkce_pair()
 
@@ -204,7 +205,8 @@ class OidcAuthorizationCode(oidc._OidcBase):
 
         if self.code_challenge is not None:
             payload.update({
-                'code_challenge': self.code_challenge
+                'code_challenge': self.code_challenge,
+                'code_challenge_method': 'S256'
             })
 
         url = "%s?%s" % (self._get_authorization_endpoint(session),

--- a/keystoneauth_oidc/plugin.py
+++ b/keystoneauth_oidc/plugin.py
@@ -15,9 +15,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import pkce
 import socket
 import webbrowser
-import pkce
 
 from keystoneauth1 import _utils as utils
 from keystoneauth1 import access

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ six>=1.10.0 # MIT
 positional>=1.1.1
 
 keystoneauth1>=2.10.0
+
+pkce>=1.0


### PR DESCRIPTION
Addition of [Proof Key for Exchange (PKCE)](https://tools.ietf.org/html/rfc7636) support for public clients.

These changes allow for the omission of the `--os-client-secret` parameter for public clients who do not have a full set of client credentials. This allows for the common use case of people accessing openstack from command line clients that act as "public clients" which should not have client secrets as per the [OAuth Spec](https://tools.ietf.org/html/rfc6749#page-14).

PKCE is thus added to counter auth code highjacking and replay attacks as recommended in the [OAuth Best Practice Guide](https://tools.ietf.org/html/draft-ietf-oauth-security-topics-16.html#section-2.1.1).