### PR TITLE
Add state parameter to the authorization code request

### DIFF
--- a/keystoneauth_oidc/plugin.py
+++ b/keystoneauth_oidc/plugin.py
@@ -18,6 +18,7 @@
 import pkce
 import socket
 import webbrowser
+import uuid
 
 from keystoneauth1 import _utils as utils
 from keystoneauth1 import access
@@ -164,6 +165,7 @@ class OidcAuthorizationCode(oidc._OidcBase):
         self.redirect_uri = "http://%s:%s" % (self.redirect_host, self.redirect_port)
         self.code_verifier = None
         self.code_challenge = None
+        self.state = uuid.uuid4().hex
         if client_secret in ['', None]:
             self.code_verifier, self.code_challenge = pkce.generate_pkce_pair()
 
@@ -201,7 +203,8 @@ class OidcAuthorizationCode(oidc._OidcBase):
         payload = {"client_id": self.client_id,
                    "response_type": "code",
                    "scope": self.scope,
-                   "redirect_uri": self.redirect_uri}
+                   "redirect_uri": self.redirect_uri,
+                   "state": self.state}
 
         if self.code_challenge is not None:
             payload.update({

--- a/keystoneauth_oidc/tests/unit/test_oidc.py
+++ b/keystoneauth_oidc/tests/unit/test_oidc.py
@@ -118,7 +118,8 @@ class OIDCAuthorizationGrantTests(test_identity_v3_oidc.BaseOIDCTests,
         payload = {"client_id": self.CLIENT_ID,
                    "response_type": "code",
                    "scope": self.plugin.scope,
-                   "redirect_uri": self.plugin.redirect_uri}
+                   "redirect_uri": self.plugin.redirect_uri,
+                   "state": self.plugin.state}
 
         url = "%s?%s" % (self.AUTHORIZATION_ENDPOINT,
                          urllib.parse.urlencode(payload))


### PR DESCRIPTION
Some OIDC providers such as Okta require this parameter to be set in the request for an authorization code